### PR TITLE
Pixel indexed

### DIFF
--- a/packages/imaging/Image/binding/bind_image.lua.cc
+++ b/packages/imaging/Image/binding/bind_image.lua.cc
@@ -435,6 +435,18 @@ using namespace Imaging;
 }
 //BIND_END
 
+//BIND_METHOD ImageFloat get_indexes
+{
+  float threshold;;
+  LUABIND_CHECK_ARGN(==, 1);
+  LUABIND_GET_PARAMETER(1, float, threshold);
+  MatrixFloat *res;
+  res = obj->get_indexes_from_image(threshold);
+  
+  LUABIND_RETURN(MatrixFloat, res);
+}
+//BIND_END
+
 //BIND_METHOD ImageFloat to_RGB
 {
   LUABIND_CHECK_ARGN(==,0);

--- a/packages/imaging/Image/c_src/image.cc
+++ b/packages/imaging/Image/c_src/image.cc
@@ -1004,7 +1004,7 @@ namespace Imaging {
       for (int col = 0; col < width; ++col)
       {
           for(int row = 0; row < height; ++row) 
-              if ((*this)(col,row) > threshold) total++;
+              if ((*this)(col,row) >= threshold) total++;
           
       }
       Basics::MatrixFloat *m_pixels = new Basics::MatrixFloat(1, total);
@@ -1016,7 +1016,7 @@ namespace Imaging {
               float value = (*this)(col,row);
               float index = (row)*width+col+1;
 
-              if ((*this)(col,row) > threshold) {
+              if ((*this)(col,row) >= threshold) {
                   (*m_pixels)(current) = index;
                   current++;
               }

--- a/packages/imaging/Image/c_src/image.cc
+++ b/packages/imaging/Image/c_src/image.cc
@@ -990,6 +990,40 @@ namespace Imaging {
     }
   }
 
+  /* Returns a vector with the indexes that of pixels that are above threshold element
+   * 
+   */
+  template <typename T>
+  Basics::MatrixFloat * Image<T>::get_indexes_from_image(T threshold) {
+
+      // Compute the number of pixels
+      int total = 0;
+      int width  = this->width();
+      int height = this->height();
+      // float eps = 0.05;
+      for (int col = 0; col < width; ++col)
+      {
+          for(int row = 0; row < height; ++row) 
+              if ((*this)(col,row) > threshold) total++;
+          
+      }
+      Basics::MatrixFloat *m_pixels = new Basics::MatrixFloat(1, total);
+
+      int current = 0;
+      for (int col= 0; col < width; ++col){
+
+          for(int row = 0; row < height; ++row) {
+              float value = (*this)(col,row);
+              float index = (row)*width+col+1;
+
+              if ((*this)(col,row) > threshold) {
+                  (*m_pixels)(current) = index;
+                  current++;
+              }
+          }
+      }
+      return m_pixels;
+  }
 } // namespace Imaging
 
 #endif // IMAGE_CC

--- a/packages/imaging/Image/c_src/image.h
+++ b/packages/imaging/Image/c_src/image.h
@@ -121,13 +121,13 @@ namespace Imaging {
 
     Basics::Matrix<T> *comb_lineal_forward(int x, int y, int ancho, int alto, int miniancho, int minialto, Basics::LinearCombConf<T> *cl);
     void threshold_image(T low, T high, T value_low, T value_high);
+    Basics::MatrixFloat * get_indexes_from_image(T threshold);
   };
 
 
   template<>
   Image<FloatRGB> *Image<FloatRGB>::convolution5x5(float *k,
                                                    FloatRGB default_color) const;
-
 }
 
   /*** Implementacion ***/

--- a/packages/imaging/Image/test/test_indexed.lua
+++ b/packages/imaging/Image/test/test_indexed.lua
@@ -1,0 +1,15 @@
+img = ImageIO.read(arg[1]):to_grayscale():invert_colors()
+
+-- Get the matrix indexes
+threshold = arg[2] or 0.5
+indexes = img:get_indexes(threshold)
+print("Indexes", indexes)
+print("Dim", #indexes:dim())
+local n_indexes = indexes:dim(1)
+local w, h = img:geometry()
+
+local total = w*h
+printf("%d/%d (%.5f) pixels are above the threshold (%f)\n",
+n_indexes, total, n_indexes/total, threshold)
+
+

--- a/packages/imaging/interest_points/c_src/interest_points.cc
+++ b/packages/imaging/interest_points/c_src/interest_points.cc
@@ -895,6 +895,7 @@ ImageFloat *get_pixel_area(ImageFloat *source,
       return m_pixels;
   }
 
+
   // Class Set Points
   SetPoints::SetPoints(ImageFloat *img) {
       // Compute connected components of the image

--- a/packages/imaging/interest_points/c_src/interest_points.h
+++ b/packages/imaging/interest_points/c_src/interest_points.h
@@ -95,7 +95,6 @@ namespace InterestPoints
 
   Imaging::ImageFloat *get_image_area_from_dataset(Basics::DataSetFloat *ds_out, Basics::DataSetFloat *indexed, int width, int height, int num_classes, float threshold = 0.8); 
   Basics::MatrixFloat * get_indexes_from_colored(Imaging::ImageFloat *img, Imaging::ImageFloat *img2=NULL);
-
   Imaging::ImageFloat *refine_colored(Imaging::ImageFloat *img, Basics::MatrixFloat *mat, int num_classes = 3);
   struct interest_point:AprilUtils::Point<int> {
     bool natural_type;


### PR DESCRIPTION
Utilities for applying a NN only to pixel over certain threshold. Useful for classifying ink pixels instead of all (background and foreground)